### PR TITLE
Remove redis configuration from config-postgres.properties.

### DIFF
--- a/docker/server/config/config-postgres.properties
+++ b/docker/server/config/config-postgres.properties
@@ -3,7 +3,6 @@ conductor.grpc-server.enabled=false
 
 # Database persistence type.
 conductor.db.type=postgres
-conductor.redis.hosts=rs:6379:primary
 
 # Hikari pool sizes are -1 by default and prevent startup
 spring.datasource.hikari.maximum-pool-size=10


### PR DESCRIPTION
Don't specify conductor.redis.hosts in the config-postgres.properties - we want to override this later.