### PR TITLE
Add a readonly ui mode. Hardcode readonly to 'on' for now.

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -26,6 +26,7 @@ import CustomRoutes from "./plugins/CustomRoutes";
 import AppBarModules from "./plugins/AppBarModules";
 import CustomAppBarButtons from "./plugins/CustomAppBarButtons";
 import Workbench from "./pages/workbench/Workbench";
+import ExcludeFromReadonlyUi from "./components/ExcludeFromReadonlyUi";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -69,9 +70,11 @@ export default function App() {
           <Button component={NavLink} path="/taskQueue">
             Task Queues
           </Button>
-          <Button component={NavLink} path="/workbench">
-            Workbench
-          </Button>
+          <ExcludeFromReadonlyUi>
+            <Button component={NavLink} path="/workbench">
+              Workbench
+            </Button>
+          </ExcludeFromReadonlyUi>
           <CustomAppBarButtons />
 
           <div className={classes.toolbarRight}>
@@ -111,9 +114,11 @@ export default function App() {
           <Route exact path="/taskQueue/:name?">
             <TaskQueue />
           </Route>
-          <Route exact path="/workbench">
-            <Workbench />
-          </Route>
+          <ExcludeFromReadonlyUi>
+            <Route exact path="/workbench">
+              <Workbench />
+            </Route>
+          </ExcludeFromReadonlyUi>
           <Route exact path="/kitchen">
             <KitchenSink />
           </Route>

--- a/ui/src/components/ExcludeFromReadonlyUi.jsx
+++ b/ui/src/components/ExcludeFromReadonlyUi.jsx
@@ -1,0 +1,7 @@
+export const READONLY_MODE_ENABLED = false;
+
+export default function ExcludeFromReadonlyUi(props) {
+  return (
+      !READONLY_MODE_ENABLED && {...props.children}
+  )
+}

--- a/ui/src/pages/definition/TaskDefinition.jsx
+++ b/ui/src/pages/definition/TaskDefinition.jsx
@@ -12,6 +12,9 @@ import ResetConfirmationDialog from "./ResetConfirmationDialog";
 import SaveTaskDialog from "./SaveTaskDialog";
 import { useTask } from "../../data/task";
 import { usePushHistory } from "../../components/NavLink";
+import ExcludeFromReadonlyUi, {
+  READONLY_MODE_ENABLED
+} from "../../components/ExcludeFromReadonlyUi";
 
 const useStyles = makeStyles({
   wrapper: {
@@ -130,24 +133,28 @@ export default function TaskDefinition() {
           {!_.isEmpty(jsonErrors) && <Pill color="red" label="Validation" />}
 
           <div className={classes.rightButtons}>
-            <Button
-              disabled={!_.isEmpty(jsonErrors) || !isModified}
-              onClick={handleOpenSave}
-            >
-              Save
-            </Button>
-            <Button
-              disabled={!isModified}
-              onClick={() => setResetDialog(true)}
-              variant="secondary"
-            >
-              Reset
-            </Button>
+            <ExcludeFromReadonlyUi>
+              <Button
+                  disabled={!_.isEmpty(jsonErrors) || !isModified}
+                  onClick={handleOpenSave}
+              >
+                Save
+              </Button>
+              <Button
+                  disabled={!isModified}
+                  onClick={() => setResetDialog(true)}
+                  variant="secondary"
+              >
+                Reset
+              </Button>
+
+            </ExcludeFromReadonlyUi>
           </div>
         </Toolbar>
         <Editor
           height="100%"
           width="100%"
+          readOnly={READONLY_MODE_ENABLED}
           theme="vs-light"
           language="json"
           value={taskJson}
@@ -158,6 +165,7 @@ export default function TaskDefinition() {
           onChange={handleChange}
           options={{
             selectOnLineNumbers: true,
+            readOnly: READONLY_MODE_ENABLED,
             minimap: {
               enabled: false,
             },

--- a/ui/src/pages/definition/WorkflowDefinition.jsx
+++ b/ui/src/pages/definition/WorkflowDefinition.jsx
@@ -28,6 +28,7 @@ import {
   KeyboardArrowLeftRounded,
   KeyboardArrowRightRounded,
 } from "@material-ui/icons";
+import ExcludeFromReadonlyUi, {READONLY_MODE_ENABLED} from "../../components/ExcludeFromReadonlyUi";
 
 const minCodePanelWidth = 500;
 const useStyles = makeStyles({
@@ -318,20 +319,21 @@ export default function Workflow() {
             )}
 
             <div className={classes.rightButtons}>
-              <Button
-                disabled={!_.isEmpty(jsonErrors) || !isModified}
-                onClick={handleOpenSave}
-              >
-                Save
-              </Button>
-              <Button
-                disabled={!isModified}
-                onClick={() => handleResetVersion(workflowVersion)}
-                variant="secondary"
-              >
-                Reset
-              </Button>
-
+              <ExcludeFromReadonlyUi>
+                <Button
+                    disabled={!_.isEmpty(jsonErrors) || !isModified}
+                    onClick={handleOpenSave}
+                >
+                  Save
+                </Button>
+                <Button
+                    disabled={!isModified}
+                    onClick={() => handleResetVersion(workflowVersion)}
+                    variant="secondary"
+                >
+                  Reset
+                </Button>
+              </ExcludeFromReadonlyUi>
               <IconButton
                 onClick={() => dispatch({ type: actions.TOGGLE_GRAPH_PANEL })}
               >
@@ -358,6 +360,7 @@ export default function Workflow() {
             options={{
               smoothScrolling: true,
               selectOnLineNumbers: true,
+              readOnly: READONLY_MODE_ENABLED,
               minimap: {
                 enabled: false,
               },

--- a/ui/src/pages/definitions/Task.jsx
+++ b/ui/src/pages/definitions/Task.jsx
@@ -6,6 +6,7 @@ import sharedStyles from "../styles";
 import { Helmet } from "react-helmet";
 import AddIcon from "@material-ui/icons/Add";
 import { useTaskDefs } from "../../data/task";
+import ExcludeFromReadonlyUi from "../../components/ExcludeFromReadonlyUi";
 
 const useStyles = makeStyles(sharedStyles);
 
@@ -58,11 +59,13 @@ export default function TaskDefinitions() {
       <Header tabIndex={1} loading={isFetching} />
 
       <div className={classes.tabContent}>
-        <div className={classes.buttonRow}>
-          <Button component={NavLink} path="/taskDef" startIcon={<AddIcon />}>
-            New Task Definition
-          </Button>
-        </div>
+        <ExcludeFromReadonlyUi>
+          <div className={classes.buttonRow}>
+            <Button component={NavLink} path="/taskDef" startIcon={<AddIcon />}>
+              New Task Definition
+            </Button>
+          </div>
+        </ExcludeFromReadonlyUi>
 
         {tasks && (
           <DataTable

--- a/ui/src/pages/definitions/Workflow.jsx
+++ b/ui/src/pages/definitions/Workflow.jsx
@@ -8,6 +8,7 @@ import Header from "./Header";
 import sharedStyles from "../styles";
 import { Helmet } from "react-helmet";
 import AddIcon from "@material-ui/icons/Add";
+import ExcludeFromReadonlyUi from "../../components/ExcludeFromReadonlyUi";
 
 const useStyles = makeStyles(sharedStyles);
 
@@ -112,15 +113,17 @@ export default function WorkflowDefinitions() {
       <Header tabIndex={0} loading={isFetching} />
 
       <div className={classes.tabContent}>
-        <div className={classes.buttonRow}>
-          <Button
-            component={NavLink}
-            path="/workflowDef"
-            startIcon={<AddIcon />}
-          >
-            New Workflow Definition
-          </Button>
-        </div>
+        <ExcludeFromReadonlyUi>
+          <div className={classes.buttonRow}>
+            <Button
+                component={NavLink}
+                path="/workflowDef"
+                startIcon={<AddIcon />}
+            >
+              New Workflow Definition
+            </Button>
+          </div>
+        </ExcludeFromReadonlyUi>
 
         {workflows && (
           <DataTable

--- a/ui/src/pages/execution/Execution.jsx
+++ b/ui/src/pages/execution/Execution.jsx
@@ -29,6 +29,7 @@ import { Helmet } from "react-helmet";
 import sharedStyles from "../styles";
 import rison from "rison";
 import { useWorkflow } from "../../data/workflow";
+import ExcludeFromReadonlyUi from "../../components/ExcludeFromReadonlyUi";
 
 const maxWindowWidth = window.innerWidth;
 const INIT_DRAWER_WIDTH = 650;
@@ -227,7 +228,9 @@ export default function Execution() {
                 <SecondaryButton onClick={refresh} style={{ marginRight: 10 }}>
                   Refresh
                 </SecondaryButton>
-                <ActionModule execution={execution} triggerReload={refresh} />
+                <ExcludeFromReadonlyUi>
+                  <ActionModule execution={execution} triggerReload={refresh} />
+                </ExcludeFromReadonlyUi>
               </div>
               <Heading level={3} gutterBottom>
                 {execution.workflowType || execution.workflowName}{" "}

--- a/ui/src/pages/executions/ResultsTable.jsx
+++ b/ui/src/pages/executions/ResultsTable.jsx
@@ -12,6 +12,7 @@ import { makeStyles } from "@material-ui/styles";
 import BulkActionModule from "./BulkActionModule";
 import executionsStyles from "./executionsStyles";
 import sharedStyles from "../styles";
+import {READONLY_MODE_ENABLED} from "../../components/ExcludeFromReadonlyUi";
 
 const useStyles = makeStyles({
   ...executionsStyles,
@@ -135,7 +136,7 @@ export default function ResultsTable({
           onSort={(column, sortDirection) => {
             setSort(column.id, sortDirection);
           }}
-          selectableRows
+          selectableRows={!READONLY_MODE_ENABLED}
           contextComponent={
             <BulkActionModule
               selectedRows={selectedRows}


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
Hide UI elements that allow mutating actions to be taken. This is a cosmetic only change - operators will need to take their own steps to ensure the associated APIs for said actions can not be reached.

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
